### PR TITLE
 New option to configure usage of ANONYMOUS SASL mechanism. 

### DIFF
--- a/jabber-core.el
+++ b/jabber-core.el
@@ -169,13 +169,14 @@ With many prefix arguments, one less is passed to `jabber-connect'."
 		   (password (cdr (assq :password alist)))
 		   (network-server (cdr (assq :network-server alist)))
 		   (port (cdr (assq :port alist)))
-		   (connection-type (cdr (assq :connection-type alist))))
+		   (connection-type (cdr (assq :connection-type alist)))
+		   (accept-anonymous-auth (cdr (assq :accept-anonymous-auth alist))))
 	      (jabber-connect
 	       (jabber-jid-username jid)
 	       (jabber-jid-server jid)
 	       (jabber-jid-resource jid)
 	       nil password network-server
-	       port connection-type)
+	       port connection-type accept-anonymous-auth)
 	      (setq connected-one t))))
 	(unless connected-one
 	  (message "All configured Jabber accounts are already connected"))))))
@@ -183,7 +184,7 @@ With many prefix arguments, one less is passed to `jabber-connect'."
 ;;;###autoload (autoload 'jabber-connect "jabber" "Connect to the Jabber server and start a Jabber XML stream.\nWith prefix argument, register a new account.\nWith double prefix argument, specify more connection details." t)
 (defun jabber-connect (username server resource &optional
 				registerp password network-server
-				port connection-type)
+				port connection-type accept-anonymous-auth)
   "Connect to the Jabber server and start a Jabber XML stream.
 With prefix argument, register a new account.
 With double prefix argument, specify more connection details."
@@ -201,7 +202,8 @@ With double prefix argument, specify more connection details."
 	 (setq password (cdr (assq :password alist)))
 	 (setq network-server (cdr (assq :network-server alist)))
 	 (setq port (cdr (assq :port alist)))
-	 (setq connection-type (cdr (assq :connection-type alist))))
+	 (setq connection-type (cdr (assq :connection-type alist)))
+	 (setq accept-anonymous-auth (cdr (assq :accept-anonymous-auth alist))))
        (when (equal current-prefix-arg '(16))
 	 ;; Double prefix arg: ask about everything.
 	 ;; (except password, which is asked about later anyway)
@@ -233,7 +235,7 @@ With double prefix argument, specify more connection details."
        (list (jabber-jid-username jid)
 	     (jabber-jid-server jid)
 	     (jabber-jid-resource jid)
-	     registerp password network-server port connection-type))))
+	     registerp password network-server port connection-type accept-anonymous-auth))))
 
   (require 'jabber)
 
@@ -251,11 +253,11 @@ With double prefix argument, specify more connection details."
 
     (push (start-jabber-connection username server resource
 				   registerp password 
-				   network-server port connection-type)
+				   network-server port connection-type accept-anonymous-auth)
 	  jabber-connections)))
 
 (define-state-machine jabber-connection
-  :start ((username server resource registerp password network-server port connection-type)
+  :start ((username server resource registerp password network-server port connection-type accept-anonymous-auth)
 	  "Start a Jabber connection."
 	  (let* ((connection-type
 		  (or connection-type jabber-default-connection-type))
@@ -274,7 +276,8 @@ With double prefix argument, specify more connection details."
 			:connection-type connection-type
 			:encrypted (eq connection-type 'ssl)
 			:network-server network-server
-			:port port)))))
+			:port port
+			:accept-anonymous-auth accept-anonymous-auth)))))
 
 (define-enter-state jabber-connection nil
   (fsm state-data)

--- a/jabber-core.el
+++ b/jabber-core.el
@@ -192,7 +192,7 @@ With double prefix argument, specify more connection details."
    (let* ((jid (completing-read "Enter your JID: " jabber-account-list nil nil nil 'jabber-account-history))
 	  (entry (assoc jid jabber-account-list))
 	  (alist (cdr entry))
-	  password network-server port connection-type registerp)
+	  password network-server port connection-type registerp accept-anonymous-auth)
      (flet ((nonempty
 	     (s)
 	     (unless (zerop (length s)) s)))

--- a/jabber-sasl.el
+++ b/jabber-sasl.el
@@ -41,9 +41,12 @@
 		      (lambda (tag)
 			(car (jabber-xml-node-children tag)))
 		      (jabber-xml-get-children mechanism-elements 'mechanism)))
+	 (accept-anonymous-auth (plist-get (fsm-get-state-data jc) :accept-anonymous-auth))
 	 (mechanism
 	  (if (and (member "ANONYMOUS" mechanisms)
-		   (or jabber-silent-mode (yes-or-no-p "Use anonymous authentication? ")))
+		   (or jabber-silent-mode
+		       (eq accept-anonymous-auth 'always)
+		       (and (eq accept-anonymous-auth nil) (yes-or-no-p "Use anonymous authentication? "))))
 	      (sasl-find-mechanism '("ANONYMOUS"))
 	    (sasl-find-mechanism mechanisms))))
 

--- a/jabber.el
+++ b/jabber.el
@@ -85,7 +85,13 @@ configure a Google Talk account like this:
 				   ;; for enforcing encryption?
 				   (const :tag "STARTTLS" starttls)
 				   (const :tag "Unencrypted" network)
-				   (const :tag "Legacy SSL/TLS" ssl))))))
+				   (const :tag "Legacy SSL/TLS" ssl)))
+		     (cons :format "%v"
+			   (const :format "" :accept-anonymous-auth)
+			   (choice :tag "Accept ANONYMOUS authentication mechanism"
+				   (const :tag "Ask" nil)
+				   (const :tag "Always" always)
+				   (const :tag "Never" never))))))
   :group 'jabber)
 
 (defcustom jabber-default-show ""

--- a/jabber.texi
+++ b/jabber.texi
@@ -1750,6 +1750,14 @@ is activated on connection.
 If the Jabber server uses a nonstandard port, specify it here.  The
 default is 5222 for STARTTLS and unencrypted connections, and 5223 for
 legacy SSL connections.
+
+@item Accept ANONYMOUS authentication mechanism
+This option specifies what to do if the Jabber server offers the ANONYMOUS
+authentication mechanism.  When this option is not set, or set to ``Ask''
+(@code{nil}) a prompt will be displayed. When set to ``Never'' (@code{never})
+the ANONYMOUS ahtentication mechanism will never be used when offered by the
+server, and when set to ``Always'' (@code{always}) this mechanism will be
+preferred over any other.
 @end table
 
 @subsection For Google Talk


### PR DESCRIPTION
New property for a jabber account, which allows user to configure if anonymous authentication should be used and skip interactive question on every connection to the server.
