### PR TITLE
Replace jabber(.org) which xmpp(.org)

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
-This is jabber.el 0.8.92, a Jabber client for Emacs.  Jabber (also known
-as XMPP) is an instant messaging system; see http://www.jabber.org for
-more information.
+This is jabber.el 0.8.92, an XMPP client for Emacs.  XMPP (also
+known as 'Jabber') is an instant messaging system; see
+http://xmpp.org for more information.
 
 Home page:    http://emacs-jabber.sourceforge.net
 Project page: http://sourceforge.net/projects/emacs-jabber

--- a/debian/control
+++ b/debian/control
@@ -9,9 +9,9 @@ Package: emacs-jabber
 Architecture: all
 Depends: gnus (>= 5.10.6-1.NO.20050713-1) | flim | emacs-snapshot | emacs22
 Description: Jabber client for Emacs/XEmacs
- jabber.el (emacs-jabber) is a Jabber client for Emacs and XEmacs.
+ jabber.el (emacs-jabber) is an XMPP (Jabber) client for Emacs and XEmacs.
  .
- Jabber is an open instant messaging system.  For more information on
- Jabber, see http://www.jabber.org/.
+ XMPP is an open instant messaging system.  For more information on
+ XMPP, see http://xmpp.org/.
  .
  Homepage: http://emacs-jabber.sourceforge.net/

--- a/jabber.texi
+++ b/jabber.texi
@@ -6,7 +6,7 @@
 
 @dircategory Emacs
 @direntry
-* jabber.el: (jabber).             Emacs Jabber client
+* jabber.el: (jabber).             Emacs XMPP (Jabber) client
 @end direntry
 
 @copying
@@ -23,7 +23,7 @@ this permission notice are preserved on all copies.
 
 @titlepage
 @title jabber.el
-@subtitle instant messaging for Jabber
+@subtitle instant messaging for XMPP (Jabber)
 @author by Magnus Henoch and Tom Berger
 
 @page
@@ -68,11 +68,11 @@ this permission notice are preserved on all copies.
 @node Introduction, Basic operation, Top, Top
 @chapter Introduction
 
-jabber.el is a Jabber client running under Emacs.  For more
-information on the open-protocol instant messaging network Jabber,
-please visit @uref{http://www.jabber.org}.
+jabber.el is an XMPP (Jabber) client running under Emacs.  For more
+information on the open instant messaging protocol,
+please visit @uref{http://xmpp.org}.
 
-As a Jabber client, jabber.el is mostly just a face in the crowd,
+As a XMPP client, jabber.el is mostly just a face in the crowd,
 except that it uses buffers where GUI clients have windows.  There is
 a roster buffer, and to chat with someone you open a chat buffer, and
 there are buffers for
@@ -117,7 +117,7 @@ jabber-muc-join} and entering the address.
 @chapter Basic operation
 
 This chapter is intended as an introduction to basic usage of
-jabber.el.  If you have used Jabber before and are familiar with the
+jabber.el.  If you have used XMPP before and are familiar with the
 terminology, you might find it a bit too basic---in that case, just
 skim it, making sure to pick up the commands mentioned.
 


### PR DESCRIPTION
where appropriate. There are still some places left where this could be
done, mostly UI strings where 'Jabber' could be replaced with
'XMPP (Jabber)'.

I didn't want to put to much effort into it (yet), before I haven't heard your opinion on this change. IMHO all occurrences where the term 'Jabber' refers to the XMPP protocol, 'Jabber' should get replaces with 'XMPP (Jabber)'.