### PR TITLE
Don’t base64-decode when there’s nothing to decode

### DIFF
--- a/jabber-sasl.el
+++ b/jabber-sasl.el
@@ -134,9 +134,9 @@ Call REMEMBER with the password.  REMEMBER is expected to return it as well."
       ;; need to pass this data to sasl.el - we're not necessarily
       ;; done just because the server says we're done.
       (let* ((data (car (jabber-xml-node-children xml-data)))
-	     (decoded (if data
-			  (base64-decode-string data)
-			"")))
+             (decoded (if (and data (not (string= data "=")))
+                          (base64-decode-string data)
+                        "")))
 	(sasl-step-set-data step decoded)
 	(condition-case e
 	    (progn


### PR DESCRIPTION
Servers are free to return the string “=” instead of actual base64 data in the
success message payload as per [1] (cf. [2]). Prosody does this as of v0.10.
Hence, despite login success, we choke when trying to base64-decode non-base64
data and get stuck after auth.

We avoid getting stuck by making sure the data is not just nil but also not a
void “=”.

[1] <http://xmpp.org/rfcs/rfc6120.html#sasl-process-neg-initiate>
[2] <https://prosody.im/issues/issue/729>

Fixes #19