### PR TITLE
XEP-0313 MAM support.

### DIFF
--- a/jabber-chat.el
+++ b/jabber-chat.el
@@ -42,13 +42,13 @@ with):
 
 (defcustom jabber-chat-header-line-format
   '("" (jabber-chat-buffer-show-avatar
-	(:eval 
+	(:eval
 	 (let ((buddy (jabber-jid-symbol jabber-chatting-with)))
 	   (jabber-propertize " "
 			      'display (get buddy 'avatar)))))
     (:eval (jabber-jid-displayname jabber-chatting-with))
     "\t" (:eval (let ((buddy (jabber-jid-symbol jabber-chatting-with)))
-		  (propertize 
+		  (propertize
 		   (or
 		    (cdr (assoc (get buddy 'show) jabber-presence-strings))
 		    (get buddy 'show))
@@ -297,7 +297,7 @@ prevents duplicate messages in the buffer)."
 	 (backlog-entries (jabber-history-backlog
 			   jabber-chatting-with jabber-chat-earliest-backlog)))
     (when backlog-entries
-      (setq jabber-chat-earliest-backlog 
+      (setq jabber-chat-earliest-backlog
 	    (jabber-float-time (jabber-parse-time
 				(aref (car backlog-entries) 0))))
       (save-excursion
@@ -336,14 +336,14 @@ prevents duplicate messages in the buffer)."
 	  (dolist (hook '(jabber-message-hooks jabber-alert-message-hooks))
 	    (run-hook-with-args hook
 				from (current-buffer) body-text
-				(funcall jabber-alert-message-function 
+				(funcall jabber-alert-message-function
 					 from (current-buffer) body-text))))))))
 
 (defun jabber-chat-send (jc body)
   "Send BODY through connection JC, and display it in chat buffer."
   ;; Build the stanza...
   (let* ((id (apply 'format "emacs-msg-%d.%d.%d" (current-time)))
-	 (stanza-to-send `(message 
+	 (stanza-to-send `(message
 			   ((to . ,jabber-chatting-with)
 			    (type . "chat")
 			    (id . ,id))
@@ -410,7 +410,7 @@ This function is used as an ewoc prettyprinter."
 	((:muc-notice :muc-error)
 	 (jabber-muc-system-prompt)))
       (put-text-property prompt-start (point) 'field 'jabber-prompt))
-    
+
     ;; ...and body
     (case (car data)
       ((:local :foreign)
@@ -485,10 +485,10 @@ If DELAYED is true, print long timestamp
 If DONT-PRINT-NICK-P is true, don't include nickname."
   (let ((from (jabber-xml-get-attribute xml-data 'from))
 	(timestamp (or timestamp (jabber-message-timestamp xml-data))))
-    (insert (jabber-propertize 
+    (insert (jabber-propertize
 	     (format-spec jabber-chat-foreign-prompt-format
 			  (list
-			   (cons ?t (format-time-string 
+			   (cons ?t (format-time-string
 				     (if delayed
 					 jabber-chat-delayed-time-format
 				       jabber-chat-time-format)
@@ -502,7 +502,7 @@ If DONT-PRINT-NICK-P is true, don't include nickname."
 	     (concat (format-time-string "On %Y-%m-%d %H:%M:%S" timestamp) " from " from)))))
 
 (defun jabber-chat-system-prompt (timestamp)
-  (insert (jabber-propertize 
+  (insert (jabber-propertize
 	   (format-spec jabber-chat-foreign-prompt-format
 			(list
 			 (cons ?t (format-time-string jabber-chat-time-format
@@ -527,10 +527,10 @@ If DONT-PRINT-NICK-P is true, don't include nickname."
 	 (server (plist-get state-data :server))
 	 (resource (plist-get state-data :resource))
 	 (nickname username))
-    (insert (jabber-propertize 
+    (insert (jabber-propertize
 	     (format-spec jabber-chat-local-prompt-format
 			  (list
-			   (cons ?t (format-time-string 
+			   (cons ?t (format-time-string
 				     (if delayed
 					 jabber-chat-delayed-time-format
 				       jabber-chat-time-format)
@@ -546,7 +546,7 @@ If DONT-PRINT-NICK-P is true, don't include nickname."
 (defun jabber-chat-print-error (xml-data)
   "Print error in given <message/> in a readable way."
   (let ((the-error (car (jabber-xml-get-children xml-data 'error))))
-    (insert 
+    (insert
      (jabber-propertize
       (concat "Error: " (jabber-parse-error the-error))
       'face 'jabber-chat-error))))
@@ -597,7 +597,7 @@ If DONT-PRINT-NICK-P is true, don't include nickname."
 			       " "
 			       action)
 		       'face 'jabber-chat-prompt-system)))
-	  (insert (jabber-propertize 
+	  (insert (jabber-propertize
 		   body
 		   'face (case who
 			   ((:foreign :muc-foreign) 'jabber-chat-text-foreign)
@@ -611,7 +611,7 @@ If DONT-PRINT-NICK-P is true, don't include nickname."
       (when (and (listp x) (eq (jabber-xml-node-name x) 'x)
 		 (string= (jabber-xml-get-attribute x 'xmlns) "jabber:x:oob"))
 	(setq foundp t)
-	
+
 	(when (eql mode :insert)
 	  (let ((url (car (jabber-xml-node-children
 			   (car (jabber-xml-get-children x 'url)))))
@@ -669,7 +669,7 @@ Returns the chat buffer."
 		      (jabber-read-jid-completing "chat with:"))
 		      (account
 		       (jabber-read-account nil jid)))
-		 (list 
+		 (list
 		  account jid current-prefix-arg)))
   (let ((buffer (jabber-chat-create-buffer jc jid nil)))
     (if other-window

--- a/jabber-core.el
+++ b/jabber-core.el
@@ -260,7 +260,7 @@ With double prefix argument, specify more connection details."
     ;;(jabber-clear-roster)
 
     (push (start-jabber-connection username server resource
-				   registerp password 
+				   registerp password
 				   network-server port connection-type)
 	  jabber-connections)))
 
@@ -272,7 +272,7 @@ With double prefix argument, specify more connection details."
 		 (send-function
 		  (jabber-get-send-function connection-type)))
 
-	    (list :connecting 
+	    (list :connecting
 		  (list :send-function send-function
 			;; Save the JID we originally connected with.
 			:original-jid (concat username "@" server)
@@ -404,9 +404,9 @@ With double prefix argument, specify more connection details."
   (fsm state-data)
 
   (jabber-send-stream-header fsm)
-  
+
   ;; Next thing happening is the server sending its own <stream:stream> start tag.
-  
+
   (list state-data nil))
 
 (define-state jabber-connection :connected
@@ -580,7 +580,7 @@ With double prefix argument, specify more connection details."
   (let ((new-state-data
 	 (plist-put state-data
 		    :sasl-data
-		    (jabber-sasl-start-auth 
+		    (jabber-sasl-start-auth
 		     fsm
 		     (plist-get state-data
 				:stream-features)))))
@@ -600,8 +600,8 @@ With double prefix argument, specify more connection details."
 
     (:stanza
      (let ((new-sasl-data
-	    (jabber-sasl-process-input 
-	     fsm (cadr event) 
+	    (jabber-sasl-process-input
+	     fsm (cadr event)
 	     (plist-get state-data :sasl-data))))
        (list :sasl-auth (plist-put state-data :sasl-data new-sasl-data))))
 
@@ -704,7 +704,7 @@ With double prefix argument, specify more connection details."
      (list :session-established state-data))
 
     (:bind-failure
-     (message "Resource binding failed: %s" 
+     (message "Resource binding failed: %s"
 	      (jabber-parse-error
 	       (jabber-iq-error (cadr event))))
      (list nil state-data))
@@ -723,7 +723,7 @@ With double prefix argument, specify more connection details."
 (define-enter-state jabber-connection :session-established
   (fsm state-data)
   (jabber-send-iq fsm nil
-		  "get" 
+		  "get"
 		  '(query ((xmlns . "jabber:iq:roster")))
 		  #'jabber-process-roster 'initial
 		  #'jabber-initial-roster-failure nil)
@@ -763,9 +763,9 @@ With double prefix argument, specify more connection details."
 	       (nconc pending-updates (list jid-symbol-to-update)))
 	     (list :session-established state-data :keep))
 	 ;; Otherwise, we need to create the list and start the timer.
-	 (setq state-data 
+	 (setq state-data
 	       (plist-put state-data
-			  :roster-pending-updates 
+			  :roster-pending-updates
 			  (list jid-symbol-to-update)))
 	 (list :session-established state-data jabber-pending-presence-timeout))))
 
@@ -853,7 +853,7 @@ DATA is any sexp."
     ;; Start from the beginning
     (goto-char (point-min))
     (let (xml-data)
-      (loop 
+      (loop
        do
        ;; Skip whitespace
        (unless (zerop (skip-chars-forward " \t\r\n"))
@@ -886,7 +886,7 @@ DATA is any sexp."
 	   (jabber-log-xml fsm "receive" stream-header)
 	   (fsm-send fsm (list :stream-start session-id stream-version))
 	   (delete-region (point-min) ending-at)))
-       
+
        ;; Normal tag
 
        ;; XXX: do these checks make sense?  If so, reinstate them.
@@ -898,7 +898,7 @@ DATA is any sexp."
        (save-excursion
 	 (while (search-forward-regexp " \\w+=''" nil t)
            (replace-match "")))
-       
+
        (setq xml-data (jabber-xml-parse-next-stanza))
 
        while xml-data
@@ -942,7 +942,7 @@ Return an fsm result list if it is."
 	     (equal (jabber-xml-get-xmlns xml-data) "http://etherx.jabber.org/streams"))
     (let ((condition (jabber-stream-error-condition xml-data))
 	  (text (jabber-parse-stream-error xml-data)))
-      (setq state-data (plist-put state-data :disconnection-reason 
+      (setq state-data (plist-put state-data :disconnection-reason
 				  (format "Stream error: %s" text)))
       ;; Special case: when the error is `conflict', we have been
       ;; forcibly disconnected by the same user.  Don't reconnect
@@ -979,7 +979,7 @@ Return an fsm result list if it is."
 (defun jabber-send-stream-header (jc)
   "Send stream header to connection JC."
   (let ((stream-header
-	 (concat "<?xml version='1.0'?><stream:stream to='" 
+	 (concat "<?xml version='1.0'?><stream:stream to='"
 		 (plist-get (fsm-get-state-data jc) :server)
 		 "' xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'"
 		 ;; Not supporting SASL is not XMPP compliant,

--- a/jabber-events.el
+++ b/jabber-events.el
@@ -21,7 +21,7 @@
 
 (require 'cl)
 
-(defgroup jabber-events nil 
+(defgroup jabber-events nil
   "Message events and notifications."
   :group 'jabber)
 
@@ -57,7 +57,7 @@ probably reading the message).")
 (make-variable-buffer-local 'jabber-events-message)
 
 (defun jabber-events-update-message ()
-  (setq jabber-events-message 
+  (setq jabber-events-message
 	(concat (cdr (assq jabber-events-arrived
 			   '((offline . "In offline storage")
 			     (delivered . "Delivered")
@@ -130,9 +130,9 @@ and it hasn't been sent before."
 	       jabber-chatting-with
 	       ;; don't send to bare jids
 	       (jabber-jid-resource jabber-chatting-with))
-      (jabber-send-sexp 
+      (jabber-send-sexp
        jabber-buffer-connection
-       `(message 
+       `(message
 	 ((to . ,jabber-chatting-with))
 	 (x ((xmlns . "jabber:x:event"))
 	    (displayed)
@@ -144,9 +144,9 @@ and it hasn't been sent before."
     (when (and jabber-events-confirm-composing
 	       jabber-chatting-with
 	       (not (eq composing-now jabber-events-composing-sent)))
-      (jabber-send-sexp 
+      (jabber-send-sexp
        jabber-buffer-connection
-       `(message 
+       `(message
 	 ((to . ,jabber-chatting-with))
 	 (x ((xmlns . "jabber:x:event"))
 	    ,@(if composing-now '((composing)) nil)
@@ -172,7 +172,7 @@ and it hasn't been sent before."
 	 ((string= (jabber-xml-get-attribute xml-data 'type) "error")
 	  (remove-hook 'post-command-hook 'jabber-events-after-change t)
 	  (setq jabber-events-requested nil))
-	  
+
 	 ;; If there's a body, it's not an incoming message event.
 	 ((jabber-xml-get-children xml-data 'body)
 	  ;; User is done composing, obviously.
@@ -184,21 +184,21 @@ and it hasn't been sent before."
 	  (setq jabber-events-delivery-confirmed nil)
 
 	  ;; User requests message events
-	  (setq jabber-events-requested 
+	  (setq jabber-events-requested
 		;; There might be empty strings in the XML data,
 		;; which car chokes on.  Having nil values in
 		;; the list won't hurt, therefore car-safe.
-		(mapcar #'car-safe 
+		(mapcar #'car-safe
 			(jabber-xml-node-children x)))
 	  (setq jabber-events-last-id (jabber-xml-get-attribute
 				       xml-data 'id))
 
 	  ;; Send notifications we already know about
-	  (flet ((send-notification 
+	  (flet ((send-notification
 		  (type)
-		  (jabber-send-sexp 
+		  (jabber-send-sexp
 		   jc
-		   `(message 
+		   `(message
 		     ((to . ,(jabber-xml-get-attribute xml-data 'from)))
 		     (x ((xmlns . "jabber:x:event"))
 			(,type)
@@ -228,7 +228,7 @@ and it hasn't been sent before."
 	  ;; We check the latter.
 	  (when (and x (jabber-xml-get-children x 'id))
 	    ;; Currently we don't care about the <id/> node.
-	
+
 	    ;; There's only one node except for the id.
 	    (unless
 		(dolist (possible-node '(offline delivered displayed))

--- a/jabber-history.el
+++ b/jabber-history.el
@@ -40,7 +40,10 @@ Jabber history files."
   :group 'jabber)
 
 (defcustom jabber-history-enabled nil
-  "Non-nil means message logging is enabled."
+  "Non-nil means message logging is enabled.
+When this variable and `jabber-history-mam' are both non-nil,
+messages are logged to files but history requests are handled by
+the MAM module (see `jabber-mam')."
   :type 'boolean
   :group 'jabber-history)
 
@@ -127,7 +130,7 @@ in the message history.")
 	     (not (file-directory-p jabber-history-dir)))
     (make-directory jabber-history-dir))
   (let ((is-muc (jabber-muc-message-p xml-data)))
-    (when (and jabber-history-enabled (not jabber-history-mam)
+    (when (and jabber-history-enabled
 	       (or
 		(not is-muc)                ;chat message or private MUC message
 		(and jabber-history-muc-enabled is-muc))) ;muc message and muc logging active
@@ -150,7 +153,7 @@ in the message history.")
     (make-directory jabber-history-dir))
   ;; This function is called from a chat buffer, so jabber-chatting-with
   ;; contains the desired value.
-  (if (and jabber-history-enabled (not jabber-history-mam))
+  (if jabber-history-enabled
       (jabber-history-log-message "out" nil jabber-chatting-with body (current-time))))
 
 (defun jabber-history-filename (contact)

--- a/jabber-iq.el
+++ b/jabber-iq.el
@@ -32,7 +32,7 @@
 (defvar jabber-iq-set-xmlns-alist nil
   "Mapping from XML namespace to handler for IQ SET requests.")
 
-(defvar jabber-browse-mode-map 
+(defvar jabber-browse-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map jabber-common-keymap)
     (define-key map [mouse-2] 'jabber-popup-combined-menu)
@@ -129,7 +129,7 @@ with XML-DATA being the IQ stanza received in response. "
 
 					       *jabber-open-info-queries*)))
     (jabber-send-sexp jc
-		      (list 'iq (append 
+		      (list 'iq (append
 				 (if to (list (cons 'to to)))
 				 (list (cons 'type type))
 				 (list (cons 'id id)))
@@ -150,7 +150,7 @@ TEXT is a string to be sent in the error message, or nil for no text.
 APP-SPECIFIC is a list of extra XML tags.
 
 See section 9.3 of XMPP Core."
-  (jabber-send-sexp 
+  (jabber-send-sexp
    jc
    `(iq (,@(when to `((to . ,to)))
 	 (type . "error")

--- a/jabber-mam.el
+++ b/jabber-mam.el
@@ -1,0 +1,206 @@
+;; jabber-mam.el - XEP-0313 Message Archive Management
+
+;; Copyright (C) 2003, 2004, 2007, 2008 - Magnus Henoch - mange@freemail.hu
+;; Copyright (C) 2002, 2003, 2004 - tom berger - object@intelectronica.net
+
+;; SSL-Connection Parts:
+;; Copyright (C) 2017 - Thibault Marin - thibault.marin@gmx.com
+
+;; This file is a part of jabber.el.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, write to the Free Software
+;; Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+;;; Commentary:
+
+;; Provides an interface to server message archives following XEP-0313 (message
+;; archive management--MAM).  To use, set `jabber-history-enabled' and
+;; `jabber-history-mam' to non-nil values.  This requires server support for
+;; XEP-0313 (http://xmpp.org/extensions/xep-0313.html) and proper configuration.
+;; In particular, the archiving behavior can be configured to select which
+;; messages are stored.  User preferences can be set by server requests
+;; (http://xmpp.org/extensions/xep-0313.html#prefs).
+
+
+;;; Code:
+
+(require 'jabber-iq)
+
+(defcustom jabber-mam-namespace "urn:xmpp:mam:0"
+  "XMPP namespace for XEP-0313 request.
+This can be determined by sending a request to the server as
+described in http://xmpp.org/extensions/xep-0313.html#support."
+  :type 'string
+  :group 'jabber-history)
+
+(defvar jabber-mam-results nil
+  "Buffer receiving the archived messages from the server.")
+
+(defvar jabber-mam-done nil
+  "Flag raised when results paged over multiple sets have been processed.")
+
+(defvar jabber-mam-lock nil
+  "Synchronization variable to return MAM results synchronously.")
+
+(defun jabber-mam-make-query (jid jid-with start-time end-time number after)
+  "Build request for server requesting archived messages.
+Request messages between JID and JID-WITH between START-TIME and END-TIME
+limiting to NUMBER results.  AFTER is used when paging through multiple result
+sets: it contains the ID (returned by the server) for the last message in each
+result set."
+  (let* ((xxmlns `(x ((xmlns . "jabber:x:data")
+                      (type . "submit"))
+                     (field ((var . "FORM_TYPE")
+                             (type . "hidden"))
+                            (value () ,jabber-mam-namespace))
+                     (field ((var . "id"))
+                            (value () ,jid))
+                     (field ((var . "with"))
+                            (value () ,jid-with))))
+         (query `(query ((xmlns . ,jabber-mam-namespace)))))
+    (when start-time
+      (add-to-list 'xxmlns `(field ((var . "start"))
+                                   (value (), (jabber-encode-time start-time)))
+                   t))
+    (when end-time
+      ;; End time is offset by 1 second to avoid duplicate messages
+      (add-to-list 'xxmlns `(field ((var . "end"))
+                                   (value (), (jabber-encode-time
+                                               (- end-time 1))))
+                   t))
+    (add-to-list 'query xxmlns t)
+    (when (or number after)
+      (let ((setxmlns '(set ((xmlns . "http://jabber.org/protocol/rsm")))))
+        (when number
+          ;; Limit number of results
+          (add-to-list 'setxmlns `(max () ,(format "%d" number)) t)
+          (add-to-list 'setxmlns '(before ()) t))
+        (when after
+          ;; Page through results (XMPP Result Set Management)
+          (add-to-list 'setxmlns `(after () ,after) t))
+      (add-to-list 'query setxmlns t)))
+    query))
+
+(add-to-list 'jabber-message-chain 'jabber-handle-incoming-mam-message)
+(defun jabber-handle-incoming-mam-message (jc xml-data)
+  "Manage results from MAM request with connection JC and content XML-DATA.
+The server returns message objects for each message using XMPP
+Result Set Management.  Paging through results is performed in the
+`jabber-mam-query' function.  Results are store in `jabber-mam-results'."
+  (cond ((jabber-xml-get-children xml-data 'result)
+         (let ((mam-jid-me (jabber-jid-user (jabber-xml-get-attribute
+                                             xml-data 'to)))
+               (mam-result (car (jabber-xml-get-children xml-data 'result))))
+           (when (jabber-xml-get-children mam-result 'forwarded)
+             ;; Extract message information (direction, timestamp, body)
+             (let* ((mam-fwd (car (jabber-xml-get-children
+                                   mam-result 'forwarded)))
+                    (mam-msg
+                     (when (jabber-xml-get-children mam-fwd 'message)
+                       (car (jabber-xml-get-children mam-fwd 'message))))
+                    (mam-stamp
+                     (when (jabber-xml-get-children mam-fwd 'delay)
+                       (jabber-xml-get-attribute
+                        (car (jabber-xml-get-children mam-fwd 'delay)) 'stamp)))
+                    (mam-msg-body
+                     (when (and mam-msg (jabber-xml-get-children mam-msg 'body))
+                       (car (jabber-xml-get-children mam-msg 'body))))
+                    (mam-msg-body-txt
+                     (when mam-msg-body
+                       (substring (format "%s" (cdr (cdr mam-msg-body))) 1 -1)))
+                    (mam-msg-from
+                     (when mam-msg
+                       (let ((mam-msg-from-t (jabber-jid-user
+                                              (jabber-xml-get-attribute
+                                               mam-msg 'from))))
+                         (if (string= mam-msg-from-t mam-jid-me)
+                             "me"
+                           mam-msg-from-t))))
+                    (mam-msg-to
+                     (when mam-msg
+                       (let ((mam-msg-to-t (jabber-jid-user
+                                            (jabber-xml-get-attribute
+                                             mam-msg 'to))))
+                         (if (string= mam-msg-to-t mam-jid-me)
+                             "me"
+                           mam-msg-to-t))))
+                    (mam-msg-dir
+                     (cond ((string= mam-msg-from "me")
+                            "out")
+                           ((string= mam-msg-to "me")
+                            "in")
+                           (t "me"))))
+               (when (and mam-stamp mam-msg-dir mam-msg-from mam-msg-to
+                          mam-msg-body-txt)
+                 (push (vector mam-stamp mam-msg-dir mam-msg-from
+                               mam-msg-to mam-msg-body-txt)
+                       jabber-mam-results))))))
+        ((jabber-xml-get-children xml-data 'fin)
+         ;; End of set, determine if a subsequent query is required (if the
+         ;; result is not complete).
+         ;; Extract "complete" attribute from <fin> tag and <last> id
+         (let* ((fin (jabber-xml-get-children xml-data 'fin))
+                (complete (jabber-xml-get-attribute (car fin) 'complete))
+                (set (jabber-xml-get-children (car fin) 'set))
+                (last
+                 (when set (jabber-xml-get-children (car set) 'last)))
+                (last-id (when last (cadr (cdr (car last))))))
+           (if (and (or (not complete) (not (string= complete "true"))) last-id)
+               ;; Result set is not complete, next request should start with
+               ;; `last-id'
+               (setq jabber-mam-last-id last-id)
+             ;; Result set is complete
+             (setq jabber-mam-done t))
+           ;; Release lock
+           (setq jabber-mam-lock t)
+           nil))
+        (t nil)))
+
+(defun jabber-mam-query (jc jid-me jid-with start-time end-time number
+                            direction)
+  "Build and send MAM query to server.
+JC is jabber connection.  Messages between users with JIDs JID-ME JID and
+JID-WITH JID with timestamp between START-TIME and END-TIME are retrieved.  The
+set of results is limited to NUMBER messages.  DIRECTION is either \"in\" or
+\"out\", or t for no limit on direction (this parameter is currently ignored)."
+
+  ;; Initialize output and lock
+  (setq jabber-mam-results (list))
+  (setq jabber-mam-done nil)
+  (setq jabber-mam-last-id nil)
+  (let ((number-left (if (integerp number) number nil)))
+    (while (not jabber-mam-done)
+      (let ((mam-query (jabber-mam-make-query
+                        jid-me jid-with
+                        start-time
+                        end-time
+                        number-left
+                        jabber-mam-last-id)))
+        ;;(message "MAM request: [%s]" (jabber-sexp2xml mam-query))
+        (setq jabber-mam-lock nil)
+        (jabber-send-iq jc nil "set" mam-query
+                        #'jabber-report-success "MAM request"
+                        #'jabber-report-success "MAM request")
+        ;; Wait for results
+        (while (not jabber-mam-lock)
+          (sit-for 1))
+        (when (integerp number)
+          (setq number-left (- number (length jabber-mam-results)))
+          (setq jabber-mam-done (or jabber-mam-done
+                                    (<= number-left 0)))))))
+  ;;(message "MAM got %d messages" (length jabber-mam-results))
+  (nreverse jabber-mam-results))
+
+(provide 'jabber-mam)
+;;; jabber-mam.el ends here

--- a/jabber-mam.el
+++ b/jabber-mam.el
@@ -1,9 +1,5 @@
 ;; jabber-mam.el - XEP-0313 Message Archive Management
 
-;; Copyright (C) 2003, 2004, 2007, 2008 - Magnus Henoch - mange@freemail.hu
-;; Copyright (C) 2002, 2003, 2004 - tom berger - object@intelectronica.net
-
-;; SSL-Connection Parts:
 ;; Copyright (C) 2017 - Thibault Marin - thibault.marin@gmx.com
 
 ;; This file is a part of jabber.el.
@@ -53,21 +49,25 @@ described in http://xmpp.org/extensions/xep-0313.html#support."
 (defvar jabber-mam-lock nil
   "Synchronization variable to return MAM results synchronously.")
 
+(defun jabber-mam-make-base-query (jid jid-with)
+  "Build basic query requesting messages between JID and JID-WITH."
+  `(x ((xmlns . "jabber:x:data")
+       (type . "submit"))
+      (field ((var . "FORM_TYPE")
+              (type . "hidden"))
+             (value () ,jabber-mam-namespace))
+      (field ((var . "id"))
+             (value () ,jid))
+      (field ((var . "with"))
+             (value () ,jid-with))))
+
 (defun jabber-mam-make-query (jid jid-with start-time end-time number after)
   "Build request for server requesting archived messages.
 Request messages between JID and JID-WITH between START-TIME and END-TIME
 limiting to NUMBER results.  AFTER is used when paging through multiple result
 sets: it contains the ID (returned by the server) for the last message in each
 result set."
-  (let* ((xxmlns `(x ((xmlns . "jabber:x:data")
-                      (type . "submit"))
-                     (field ((var . "FORM_TYPE")
-                             (type . "hidden"))
-                            (value () ,jabber-mam-namespace))
-                     (field ((var . "id"))
-                            (value () ,jid))
-                     (field ((var . "with"))
-                            (value () ,jid-with))))
+  (let* ((xxmlns (jabber-mam-make-base-query jid jid-with))
          (query `(query ((xmlns . ,jabber-mam-namespace)))))
     (when start-time
       (add-to-list 'xxmlns `(field ((var . "start"))
@@ -92,6 +92,79 @@ result set."
       (add-to-list 'query setxmlns t)))
     query))
 
+(defun jabber-mam-process-entry (mam-result)
+  "Extract message information from MAM-RESULT and add to results list.
+The output message information is stored in `jabber-mam-results'
+in the same format as the one used by the file archive.  The
+message is dropped if the function fails to fully extract the
+message information (timestamp, from/to, body)."
+  (let* ((mam-fwd (car (jabber-xml-get-children mam-result 'forwarded)))
+         ;; Get <message> tag
+         (mam-msg (when (jabber-xml-get-children mam-fwd 'message)
+                    (car (jabber-xml-get-children mam-fwd 'message))))
+         ;; Get timestamp
+         (mam-stamp (when (jabber-xml-get-children mam-fwd 'delay)
+                      (jabber-xml-get-attribute
+                       (car (jabber-xml-get-children mam-fwd 'delay)) 'stamp)))
+         ;; Get message body
+         (mam-msg-body
+          (when (and mam-msg (jabber-xml-get-children mam-msg 'body))
+            (car (jabber-xml-get-children mam-msg 'body))))
+         ;; Render message body
+         (mam-msg-body-txt
+          (when mam-msg-body
+            (substring (format "%s" (cdr (cdr mam-msg-body))) 1 -1)))
+         ;; Get <from> tag
+         (mam-msg-from
+          (when mam-msg
+            (let ((mam-msg-from-t (jabber-jid-user (jabber-xml-get-attribute
+                                                    mam-msg 'from))))
+              (if (string= mam-msg-from-t mam-jid-me) "me"
+                mam-msg-from-t))))
+         ;; Get <to> tag
+         (mam-msg-to
+          (when mam-msg
+            (let ((mam-msg-to-t (jabber-jid-user (jabber-xml-get-attribute
+                                                  mam-msg 'to))))
+              (if (string= mam-msg-to-t mam-jid-me) "me"
+                mam-msg-to-t))))
+         ;; Get message direction (from "me" or to "me")
+         (mam-msg-dir (cond ((string= mam-msg-from "me") "out")
+                            ((string= mam-msg-to "me") "in")
+                            (t "me"))))
+    (when (and mam-stamp mam-msg-dir mam-msg-from mam-msg-to mam-msg-body-txt)
+      ;; Push to results list
+      (push (vector
+             mam-stamp mam-msg-dir mam-msg-from mam-msg-to mam-msg-body-txt)
+            jabber-mam-results))))
+
+(defun jabber-mam-process-fin (xml-data)
+  "Process final server response from XML-DATA and determine the next action.
+This function handles the server response corresponding to the
+end of a result set.  If the <complete> tag is found, then no
+subsequent query is required (`jabber-mam-done' is set to t).  If
+the result set is not complete, the <last-id> tag is stored (in
+`jabber-mam-last-id') and used to initialize a continuation
+request.
+
+In both cases, the lock (`jabber-mam-lock') is released for the caller
+\('jabber-mam-query') to continue."
+  (let* ((fin (jabber-xml-get-children xml-data 'fin))
+         (complete (jabber-xml-get-attribute (car fin) 'complete))
+         (set (jabber-xml-get-children (car fin) 'set))
+         (last
+          (when set (jabber-xml-get-children (car set) 'last)))
+         (last-id (when last (cadr (cdr (car last))))))
+    (if (and (or (not complete) (not (string= complete "true"))) last-id)
+        ;; Result set is not complete, next request should start with
+        ;; `last-id'
+        (setq jabber-mam-last-id last-id)
+      ;; Result set is complete
+      (setq jabber-mam-done t))
+    ;; Release lock
+    (setq jabber-mam-lock t)
+    nil))
+
 (add-to-list 'jabber-message-chain 'jabber-handle-incoming-mam-message)
 (defun jabber-handle-incoming-mam-message (jc xml-data)
   "Manage results from MAM request with connection JC and content XML-DATA.
@@ -103,68 +176,14 @@ Result Set Management.  Paging through results is performed in the
                                              xml-data 'to)))
                (mam-result (car (jabber-xml-get-children xml-data 'result))))
            (when (jabber-xml-get-children mam-result 'forwarded)
-             ;; Extract message information (direction, timestamp, body)
-             (let* ((mam-fwd (car (jabber-xml-get-children
-                                   mam-result 'forwarded)))
-                    (mam-msg
-                     (when (jabber-xml-get-children mam-fwd 'message)
-                       (car (jabber-xml-get-children mam-fwd 'message))))
-                    (mam-stamp
-                     (when (jabber-xml-get-children mam-fwd 'delay)
-                       (jabber-xml-get-attribute
-                        (car (jabber-xml-get-children mam-fwd 'delay)) 'stamp)))
-                    (mam-msg-body
-                     (when (and mam-msg (jabber-xml-get-children mam-msg 'body))
-                       (car (jabber-xml-get-children mam-msg 'body))))
-                    (mam-msg-body-txt
-                     (when mam-msg-body
-                       (substring (format "%s" (cdr (cdr mam-msg-body))) 1 -1)))
-                    (mam-msg-from
-                     (when mam-msg
-                       (let ((mam-msg-from-t (jabber-jid-user
-                                              (jabber-xml-get-attribute
-                                               mam-msg 'from))))
-                         (if (string= mam-msg-from-t mam-jid-me)
-                             "me"
-                           mam-msg-from-t))))
-                    (mam-msg-to
-                     (when mam-msg
-                       (let ((mam-msg-to-t (jabber-jid-user
-                                            (jabber-xml-get-attribute
-                                             mam-msg 'to))))
-                         (if (string= mam-msg-to-t mam-jid-me)
-                             "me"
-                           mam-msg-to-t))))
-                    (mam-msg-dir
-                     (cond ((string= mam-msg-from "me")
-                            "out")
-                           ((string= mam-msg-to "me")
-                            "in")
-                           (t "me"))))
-               (when (and mam-stamp mam-msg-dir mam-msg-from mam-msg-to
-                          mam-msg-body-txt)
-                 (push (vector mam-stamp mam-msg-dir mam-msg-from
-                               mam-msg-to mam-msg-body-txt)
-                       jabber-mam-results))))))
+             ;; Extract message information (direction, timestamp, body), push
+             ;; to results list
+             (jabber-mam-process-entry mam-result))))
         ((jabber-xml-get-children xml-data 'fin)
          ;; End of set, determine if a subsequent query is required (if the
          ;; result is not complete).
          ;; Extract "complete" attribute from <fin> tag and <last> id
-         (let* ((fin (jabber-xml-get-children xml-data 'fin))
-                (complete (jabber-xml-get-attribute (car fin) 'complete))
-                (set (jabber-xml-get-children (car fin) 'set))
-                (last
-                 (when set (jabber-xml-get-children (car set) 'last)))
-                (last-id (when last (cadr (cdr (car last))))))
-           (if (and (or (not complete) (not (string= complete "true"))) last-id)
-               ;; Result set is not complete, next request should start with
-               ;; `last-id'
-               (setq jabber-mam-last-id last-id)
-             ;; Result set is complete
-             (setq jabber-mam-done t))
-           ;; Release lock
-           (setq jabber-mam-lock t)
-           nil))
+         (jabber-mam-process-fin (xml-data)))
         (t nil)))
 
 (defun jabber-mam-query (jc jid-me jid-with start-time end-time number
@@ -174,7 +193,6 @@ JC is jabber connection.  Messages between users with JIDs JID-ME JID and
 JID-WITH JID with timestamp between START-TIME and END-TIME are retrieved.  The
 set of results is limited to NUMBER messages.  DIRECTION is either \"in\" or
 \"out\", or t for no limit on direction (this parameter is currently ignored)."
-
   ;; Initialize output and lock
   (setq jabber-mam-results (list))
   (setq jabber-mam-done nil)
@@ -195,6 +213,7 @@ set of results is limited to NUMBER messages.  DIRECTION is either \"in\" or
         ;; Wait for results
         (while (not jabber-mam-lock)
           (sit-for 1))
+        ;; Update counter for remaining messages
         (when (integerp number)
           (setq number-left (- number (length jabber-mam-results)))
           (setq jabber-mam-done (or jabber-mam-done

--- a/jabber-mam.el
+++ b/jabber-mam.el
@@ -21,11 +21,11 @@
 ;;; Commentary:
 
 ;; Provides an interface to server message archives following XEP-0313 (message
-;; archive management--MAM).  To use, set `jabber-history-enabled' and
-;; `jabber-history-mam' to non-nil values.  This requires server support for
-;; XEP-0313 (http://xmpp.org/extensions/xep-0313.html) and proper configuration.
-;; In particular, the archiving behavior can be configured to select which
-;; messages are stored.  User preferences can be set by server requests
+;; archive management--MAM).  To use, set `jabber-history-mam' to a non-nil
+;; value.  This requires server support for XEP-0313
+;; (http://xmpp.org/extensions/xep-0313.html) and proper configuration.  In
+;; particular, the archiving behavior can be configured to select which messages
+;; are stored.  User preferences can be set by server requests
 ;; (http://xmpp.org/extensions/xep-0313.html#prefs).
 
 

--- a/jabber-muc.el
+++ b/jabber-muc.el
@@ -238,7 +238,7 @@ This function is idempotent."
   "Remove GROUP from internal bookkeeping."
   (let ((whichgroup (assoc group *jabber-active-groupchats*))
 	(whichparticipants (assoc group jabber-muc-participants)))
-    (setq *jabber-active-groupchats* 
+    (setq *jabber-active-groupchats*
 	  (delq whichgroup *jabber-active-groupchats*))
     (setq jabber-muc-participants
 	  (delq whichparticipants jabber-muc-participants))))
@@ -293,7 +293,7 @@ in the user entering/staying in the room."
   (when (plist-get new-plist 'jid)
     ;; nickname is only used for displaying, so we can modify it if we
     ;; want to.
-    (setq nickname (concat nickname " <" 
+    (setq nickname (concat nickname " <"
 			   (jabber-jid-user (plist-get new-plist 'jid))
 			   ">")))
   (cond
@@ -444,7 +444,7 @@ enter it."
 	  (setq xdata x)))
     (if (not xdata)
 	(insert "No configuration possible.\n")
-      
+
     (jabber-init-widget-buffer (jabber-xml-get-attribute xml-data 'from))
     (setq jabber-buffer-connection jc)
 
@@ -493,7 +493,7 @@ enter it."
   "join a groupchat, or change nick.
 In interactive calls, or if POPUP is true, switch to the
 groupchat buffer."
-  (interactive 
+  (interactive
    (let ((account (jabber-read-account))
 	 (group (jabber-read-jid-completing "group: ")))
      (list account group (jabber-muc-read-my-nickname account group) t)))
@@ -563,7 +563,7 @@ groupchat buffer."
   ;; The response might come quicker than you think.
 
   (puthash (jabber-jid-symbol group) nickname jabber-pending-groupchats)
-  
+
   (jabber-send-sexp jc
 		    `(presence ((to . ,(format "%s/%s" group nickname)))
 			       (x ((xmlns . "http://jabber.org/protocol/muc"))
@@ -594,7 +594,7 @@ groupchat buffer."
     (if default
         default-nickname
         (jabber-read-with-input-method (format "Nickname: (default %s) "
-					   default-nickname) 
+					   default-nickname)
 				   nil nil default-nickname))))
 
 (add-to-list 'jabber-jid-muc-menu
@@ -845,7 +845,7 @@ include groupchat invites."
   ;; are from room@server.
   (let ((from (jabber-xml-get-attribute message 'from))
 	(type (jabber-xml-get-attribute message 'type)))
-    (or 
+    (or
      (string= type "groupchat")
      (and (string= type "error")
 	  (gethash (jabber-jid-symbol from) jabber-pending-groupchats))
@@ -880,7 +880,7 @@ include groupchat invites."
   "Return non-nil if PRESENCE is presence from groupchat."
   (let ((from (jabber-xml-get-attribute presence 'from))
 	(type (jabber-xml-get-attribute presence 'type))
-	(muc-marker (find-if 
+	(muc-marker (find-if
 		     (lambda (x) (equal (jabber-xml-get-attribute x 'xmlns)
 				   "http://jabber.org/protocol/muc#user"))
 		     (jabber-xml-get-children presence 'x))))
@@ -906,7 +906,7 @@ Return nil if X-MUC is nil."
 	(insert (jabber-propertize
 		 (format-spec jabber-groupchat-prompt-format
 			      (list
-			       (cons ?t (format-time-string 
+			       (cons ?t (format-time-string
 					 (if timestamp
 					     jabber-chat-delayed-time-format
 					   jabber-chat-time-format)
@@ -938,7 +938,7 @@ Return nil if X-MUC is nil."
     (insert (jabber-propertize
 	     (format-spec jabber-muc-private-foreign-prompt-format
 			  (list
-			   (cons ?t (format-time-string 
+			   (cons ?t (format-time-string
 				     (if timestamp
 					 jabber-chat-delayed-time-format
 				       jabber-chat-time-format)
@@ -971,7 +971,7 @@ Return nil if X-MUC is nil."
 	   (group (jabber-jid-user from))
 	   (nick (jabber-jid-resource from))
 	   (error-p (jabber-xml-get-children xml-data 'error))
-	   (type (cond 
+	   (type (cond
 		  (error-p :muc-error)
 		  ((string= nick (cdr (assoc group *jabber-active-groupchats*)))
 		   :muc-local)
@@ -1005,7 +1005,7 @@ Return nil if X-MUC is nil."
 (defun jabber-muc-process-presence (jc presence)
   (let* ((from (jabber-xml-get-attribute presence 'from))
 	 (type (jabber-xml-get-attribute presence 'type))
-	 (x-muc (find-if 
+	 (x-muc (find-if
 		 (lambda (x) (equal (jabber-xml-get-attribute x 'xmlns)
 			       "http://jabber.org/protocol/muc#user"))
 		 (jabber-xml-get-children presence 'x)))
@@ -1024,7 +1024,7 @@ Return nil if X-MUC is nil."
 			    (jabber-xml-get-attribute status-element 'code))
 			  (jabber-xml-get-children x-muc 'status)))))
     ;; handle leaving a room
-    (cond 
+    (cond
      ((or (string= type "unavailable") (string= type "error"))
       ;; error from room itself? or are we leaving?
       (if (or (null nickname)
@@ -1077,7 +1077,7 @@ Return nil if X-MUC is nil."
 	       (jid (plist-get plist 'jid))
 	       (name (concat nickname
 			     (when jid
-			       (concat " <" 
+			       (concat " <"
 				       (jabber-jid-user jid)
 				       ">")))))
 	  (jabber-muc-remove-participant group nickname)
@@ -1101,7 +1101,7 @@ Return nil if X-MUC is nil."
 		     (t
 		      (concat name " has left the chatroom")))
 		    :time (current-time))))))))
-     (t 
+     (t
       ;; someone is entering
 
       (when (or (member "110" status-codes) (string= nickname our-nickname))
@@ -1165,7 +1165,7 @@ Return nil if X-MUC is nil."
 			 (insert ".")
 			 (buffer-string))
 		       :time (current-time))))))))))))
-	      
+
 (provide 'jabber-muc)
 
 ;;; arch-tag: 1ff7ab35-1717-46ae-b803-6f5b3fb2cd7d

--- a/jabber-presence.el
+++ b/jabber-presence.el
@@ -236,7 +236,7 @@ CLOSURE-DATA should be 'initial if initial roster push, nil otherwise."
 
 (defun jabber-process-subscription-request (jc from presence-status)
   "process an incoming subscription request"
-  (with-current-buffer (jabber-chat-create-buffer jc from)
+  (with-current-buffer (jabber-chat-create-buffer jc from nil)
     (ewoc-enter-last jabber-chat-ewoc (list :subscription-request presence-status :time (current-time)))
 
     (dolist (hook '(jabber-presence-hooks jabber-alert-presence-hooks))


### PR DESCRIPTION
This is an attempt at implementing support for XEP-0313 Message Archive Management (http://xmpp.org/extensions/xep-0313.html).

I am testing this with a prosody server (Prosody trunk nightly build 732 (2016-12-19, 8efd51667622)) and mercurial prosody-modules (https://hg.prosody.im/prosody-modules/ changeset 2462:81127dcdb326).

It would be useful if people could test this and report.