### PR TITLE
Use assoc-string instead of removed assoc-ignore-case

### DIFF
--- a/jabber-util.el
+++ b/jabber-util.el
@@ -272,8 +272,8 @@ If FULLJIDS is non-nil, complete jids with resources."
 			    jid-completion-table
 			    nil require-match nil 'jabber-jid-history jid-at-point)))
       (setq chosen
-	    (if (and input (assoc-ignore-case input jid-completion-table))
-		(symbol-name (cdr (assoc-ignore-case input jid-completion-table)))
+	    (if (and input (assoc-string input jid-completion-table))
+		(symbol-name (cdr (assoc-string input jid-completion-table)))
 	      (and (not (zerop (length input)))
 		   input))))
 


### PR DESCRIPTION
The assoc-ignore-case function has been deprecated in emacs 22 and is now removed from master.