### PR TITLE
Fixes jabber-parse-time bug in parsing fractional seconds

### DIFF
--- a/jabber-util.el
+++ b/jabber-util.el
@@ -486,8 +486,8 @@ TIME is in a format accepted by `format-time-string'."
 	 (hour (string-to-number (substring time 11 13)))
 	 (minute (string-to-number (substring time 14 16)))
 	 (second (string-to-number (substring time 17 19)))
-	 ;; fractions are optional
          (timezone (if (eq (aref time 19) ?.)
+                       ;; fractions are optional
                        (let ((timezone (cadr
                                         (split-string (substring time 20)
                                                       "[-+Z]"))))

--- a/jabber-util.el
+++ b/jabber-util.el
@@ -488,8 +488,9 @@ TIME is in a format accepted by `format-time-string'."
 	 (second (string-to-number (substring time 17 19)))
 	 ;; fractions are optional
          (timezone (if (eq (aref time 19) ?.)
-                       (let* ((r (split-string (substring time 20) "[-+Z]"))
-                              (timezone (cadr r)))
+                       (let ((timezone (cadr
+                                        (split-string (substring time 20)
+                                                      "[-+Z]"))))
                          (if (string= "" timezone)
                              "Z"
                            timezone))

--- a/jabber-util.el
+++ b/jabber-util.el
@@ -487,9 +487,13 @@ TIME is in a format accepted by `format-time-string'."
 	 (minute (string-to-number (substring time 14 16)))
 	 (second (string-to-number (substring time 17 19)))
 	 ;; fractions are optional
-	 (fraction (if (eq (aref time 19) ?.)
-		       (string-to-number (substring time 20 23))))
-	 (timezone (substring time (if fraction 23 19))))
+         (timezone (if (eq (aref time 19) ?.)
+                       (let* ((r (split-string (substring time 20) "[-+Z]"))
+                              (timezone (cadr r)))
+                         (if (string= "" timezone)
+                             "Z"
+                           timezone))
+                     (substring time 19))))
     ;; timezone is either Z (UTC) or [+-]HH:MM
     (let ((timezone-seconds
 	   (if (string= timezone "Z")


### PR DESCRIPTION
This PR fixes an issue in `jabber-parse-time` where a timestamp string with higher resolution fractional second part causes timezone parsing to fail. Fixes #25 