### PR TITLE
Fix use of make-obsolete

### DIFF
--- a/jabber-menu.el
+++ b/jabber-menu.el
@@ -133,7 +133,7 @@ With prefix argument, remove it."
   (interactive "P")
   (setq jabber-display-menu (if remove nil t))
   (force-mode-line-update))
-(make-obsolete 'jabber-menu "set the variable `jabber-display-menu' instead.")
+(make-obsolete 'jabber-menu "set the variable `jabber-display-menu' instead." "2008-10-23")
 
 ;; This used to be:
 ;; (define-key-after global-map [menu-bar jabber-menu] ...)

--- a/jabber-roster.el
+++ b/jabber-roster.el
@@ -816,7 +816,7 @@ three being lists of JID symbols."
 (defalias 'jabber-presence-update-roster 'ignore)
 ;;jabber-presence-update-roster is not needed anymore.
 ;;Its work is done in `jabber-process-presence'."
-(make-obsolete 'jabber-presence-update-roster 'ignore)
+(make-obsolete 'jabber-presence-update-roster 'ignore "2007-04-01")
 
 (defun jabber-next-property (&optional prev)
   "Return position of next property appearence or nil if there is none.


### PR DESCRIPTION
Two-argument version was obsoleted in 23.1 and will be removed in 28.1